### PR TITLE
feat: add setting page for edit name of profile

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,6 +11,8 @@ import { CoinFluxComponent } from './page/coin/flux/coin-flux.component'
 
 import { NodeDashboardComponent } from './page/node/dashboard/node-dashboard.component'
 
+import { SettingComponent } from './page/setting/setting.component';
+
 const routes: Routes = [
   {
     path: '',
@@ -31,6 +33,10 @@ const routes: Routes = [
       {
         path: 'node',
         component: NodeDashboardComponent
+      },
+      {
+        path: 'setting',
+        component: SettingComponent
       }
     ]
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,8 @@ import { CoinFluxComponent } from './page/coin/flux/coin-flux.component'
 
 import { NodeDashboardComponent } from './page/node/dashboard/node-dashboard.component'
 
+import { SettingComponent } from './page/setting/setting.component'
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -29,7 +31,8 @@ import { NodeDashboardComponent } from './page/node/dashboard/node-dashboard.com
     PortfolioOverviewComponent,
     CoinFluxComponent,
     NodeDashboardComponent,
-    MdlAddWalletComponent
+    MdlAddWalletComponent,
+    SettingComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/layouts/navbar/navbar.component.html
+++ b/src/app/layouts/navbar/navbar.component.html
@@ -22,7 +22,7 @@
             <div class="d-flex" role="search">
                 <div class="ui left labeled button" tabindex="0">
                     <a class="ui basic right pointing label" data-bs-toggle="modal" data-bs-target="#changeProfileMdl">{{profileActiveName}}</a>
-                    <div class="ui teal button"><i class="fa-solid fa-user-gear"></i></div>
+                    <div class="ui teal button" routerLink="setting"><i class="fa-solid fa-user-gear"></i></div>
                 </div>
             </div>
         </div>

--- a/src/app/page/setting/setting.component.html
+++ b/src/app/page/setting/setting.component.html
@@ -1,0 +1,19 @@
+<div class="ui hidden divider"></div>
+<div class="container">
+    <ng-container *ngIf="isEdit">
+        <div class="d-flex flex-row fluid ui dividing header">
+            <div class="p-1 flex-grow-1 ui input">
+                <input  [(ngModel)]="imputName" type="text">
+            </div>
+            <div class="p-1">
+                <button type="button" class="ui teal button mt-2" (click)="save()">Save</button>
+            </div>
+            <div class="p-1">
+                <button type="button" class="ui button mt-2" (click)="toggleEdit()">Cancel</button>
+            </div>
+        </div>
+    </ng-container>
+    <ng-container *ngIf="!isEdit">
+        <h2 class="ui dividing header">{{activeProfileName}} <span (click)="editClick()" style="cursor: pointer;"><i class="fa-solid fa-pencil"></i></span></h2>
+    </ng-container>
+</div>

--- a/src/app/page/setting/setting.component.ts
+++ b/src/app/page/setting/setting.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'setting',
+    templateUrl: './setting.component.html',
+    styleUrls: ['./setting.component.scss']
+})
+
+export class SettingComponent implements OnInit {
+    isEdit = false
+    profile = {
+        profile : [
+            {
+                name: ''
+            }
+        ]
+    }
+    profileActive = 0
+    imputName = ""
+
+    constructor(
+        
+    ) {
+        
+    }
+
+    get activeProfileName(): string {
+        return this.profile.profile[this.profileActive].name
+    }
+    set activeProfileName(newName: string) {
+        this.profile.profile[this.profileActive].name = newName
+        localStorage.setItem('profile', JSON.stringify(this.profile));
+    }
+
+    ngOnInit() {
+        if(!localStorage.getItem('profile')) {
+            localStorage.setItem('profile', JSON.stringify(this.profile));
+            localStorage.setItem('profileActive', '0');
+        }
+
+        this.profile = JSON.parse(localStorage.getItem('profile') || '{}')
+        this.profileActive = +JSON.parse(localStorage.getItem('profileActive') || "0")
+    }
+
+    save() {
+        this.activeProfileName = this.imputName
+        this.toggleEdit()
+    }
+
+    editClick() {
+        this.imputName = this.activeProfileName
+        this.toggleEdit()
+    }
+
+    toggleEdit() {
+        this.isEdit = !this.isEdit
+    }
+}


### PR DESCRIPTION
Add setting page for edit name of profile

1. Can click edit icon to edit profile name
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/7018802/168842280-2a0ba076-f99e-4fbb-b41b-4ee657886f1b.png">
2. Change profile name and save
<img width="1350" alt="image" src="https://user-images.githubusercontent.com/7018802/168842364-39e02a08-a763-46c8-a4cd-65819805d9de.png">

Resolve: #6  
